### PR TITLE
Create ICAHostKeeper with correct params

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -447,7 +447,7 @@ func NewAppKeeper(
 		appCodec,
 		appKeepers.keys[icahosttypes.StoreKey],
 		appKeepers.GetSubspace(icahosttypes.SubModuleName),
-		nil,
+		appKeepers.IBCKeeper.ChannelKeeper,
 		appKeepers.IBCKeeper.ChannelKeeper,
 		appKeepers.IBCKeeper.PortKeeper,
 		appKeepers.AccountKeeper,


### PR DESCRIPTION
Ref #199.

Provide ChannelKeeper as the definition of ICAHostKeeper constructor's ics4wrapper parameter, such that this is defined in the keeper when we come to receive packet. 

Currently the value passed is nil; this causes GetAppVersion() to panic (due to being called on k.ics4wrapper, which is nil) when receiving packets over ICA.